### PR TITLE
re-implement deployment step to server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,15 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ghcr.io/langaracpsc/langaracpsc-next:latest
+
+  deployment: 
+    needs: docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy docker package on LCSC server
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://watchtower.langaracs.tech/v1/update'
+          method: 'GET'
+          bearerToken: ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}
+          timeout: 20000


### PR DESCRIPTION
Finally figured out why the deployment step failed sometimes - its because the default timeout in `http-request-action` is 5 seconds, and sometimes Watchtower takes longer than that to respond because it's downloading and installing the new image