### PR TITLE
increase timeout so that build succeeds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,4 @@ jobs:
           url: 'https://watchtower.langaracs.tech/v1/update'
           method: 'GET'
           bearerToken: ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}
-          timeout: 20000
+          timeout: 60000


### PR DESCRIPTION
see #24 - looks like 20 seconds wasn't enough for the image to be downloaded and deployed on the server; bumped it up to 60 seconds