### PR TITLE
increase Watchtower timeout further

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,4 @@ jobs:
           url: 'https://watchtower.langaracs.tech/v1/update'
           method: 'GET'
           bearerToken: ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}
-          timeout: 60000
+          timeout: 180000


### PR DESCRIPTION
![image](https://github.com/langaracpsc/langaracpsc-next/assets/45698812/98934bf9-d96c-4ab2-81a0-951a79502e37)

Turns out that it takes about a minute and a half to pull and deploy the image (it takes SEVENTEEN SECONDS FOR PEREGRINE)

Bumped the timeout to 3 minutes.
(yes, this means that the website has about 30 seconds of downtime between deployments, thats good enough for me)