### PR TITLE
Significantly decrease build times and image size

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,17 +1,23 @@
-FROM node:21
-WORKDIR /usr/src/app
+FROM node:lts-bookworm-slim
 
-COPY . ./
+USER node
+WORKDIR /home/src/app
 
+# Due to Docker's caching system this makes rebuilding the docker image much faster
+COPY package.json package.json
+COPY package-lock.json package-lock.json
+RUN yarn install --production --immutable --immutable-cache && yarn cache clean
+
+COPY . .
+RUN yarn build
+
+# TODO: currently, we're committing secrets to the built image as it is neccessary for the API
+# this should not be done and instead the secrets should be injected into the running image
 ARG APIURL
 ARG APIKEY
 
 ENV APIURL=${APIURL}
 ENV APIKEY=${APIKEY}
-
-# building the app
-RUN yarn install
-RUN yarn run build
 
 # Running the app
 CMD [ "yarn", "start" ]


### PR DESCRIPTION
Significant improvements to `docker build .`
 - cold start boot time: 8m43s ->  2m10s
- build time when changing files in `/src`: ~2m -> 40s
- image size: ~4 GB -> 950 MB

Partial fix for #26